### PR TITLE
Migrate project management to uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ OB_DB_SSL_CA_PATH="optional-ssl-ca-path"
 
 5. Visit https://www.kaggle.com/datasets/audreyhengruizhang/china-city-attraction-details to obtain the dataset and store it in the manualy created `citydata` directory under this project directory.
 
-6. (Optional but Recomanded) Create an Python3.10 environment with [miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install).
+6. (Optional but Recommended) Install [uv](https://github.com/astral-sh/uv) for fast Python package management:
 
 ```bash
-conda create -n obmms python=3.10 && conda activate obmms
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-7. Install this python project with `poetry install`.
+7. Install this python project with `uv sync`.
 
 8. Import datas into OceanBase with following command:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,31 +1,34 @@
-[tool.poetry]
+[project]
 name = "obmms"
 version = "0.1.0"
 description = "A demo for OceanBase multi-model search"
-authors = ["shanhaikang.shk <shanhaikang.shk@oceanbase.com>"]
-license = "Apache-2.0"
+authors = [
+    {name = "shanhaikang.shk", email = "shanhaikang.shk@oceanbase.com"}
+]
+license = {text = "Apache-2.0"}
 readme = "README.md"
-packages = [{include = "obmms", from = "src"}]
+requires-python = ">=3.10"
+dependencies = [
+    "dashscope>=1.20.12",
+    "pydantic>=2.9.2",
+    "pytest>=8.3.3",
+    "pandas>=2.2.3",
+    "pyobvector==0.1.18",
+    "tqdm>=4.66.6",
+    "streamlit>=1.40.0",
+    "folium>=0.18.0",
+    "streamlit-folium>=0.23.1",
+    "python-dotenv>=0.9.9",
+]
 
-[tool.poetry.dependencies]
-python = "^3.10"
-dashscope = "^1.20.12"
-pydantic = "^2.9.2"
-pytest = "^8.3.3"
-pandas = "^2.2.3"
-pyobvector = "0.1.18"
-tqdm = "^4.66.6"
-streamlit = "^1.40.0"
-folium = "^0.18.0"
-streamlit-folium = "^0.23.1"
-dotenv = "^0.9.9"
+[tool.uv]
+package = true
 
-
-[[tool.poetry.source]]
-name = "mirrors"
+[[tool.uv.index]]
+name = "tsinghua"
 url = "https://pypi.tuna.tsinghua.edu.cn/simple/"
-priority = "primary"
+default = true
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary

This PR migrates the project from poetry to uv for faster and more efficient Python package management.

## Changes

- **Updated `pyproject.toml`**: Converted from poetry format to PEP 621 standard format
- **Modernized dependencies**: Using standard dependency specification syntax
- **Configured uv**: Added Tsinghua mirror for faster downloads in China
- **Updated documentation**: Modified README.md to reference uv instead of poetry
- **Fixed package name**: Changed `dotenv` to `python-dotenv` (correct package name)
- **Updated build system**: Switched from poetry-core to hatchling

## Benefits

- ⚡ **10-100x faster** package installation compared to pip/poetry
- 🔒 **Better reproducibility** with uv.lock file
- 📦 **Modern standards** compliant with PEP 621
- 🚀 **Simpler setup** - single command to install all dependencies

## Migration Guide

Users can now install the project with:

```bash
# Install uv
curl -LsSf https://astral.sh/uv/install.sh | sh

# Install project dependencies
uv sync
```

Closes #8