### PR TITLE
Regenerate comprehensive .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,193 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# poetry
 poetry.lock
-__pycache__
-__MACOSX
-citydata
-citydata.zip
-log
-nohup.out
+
+# pdm
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
 .env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# uv
+.uv/
+uv.lock
+
+# IDEs and Editors
+.vscode/
+.idea/
+*.swp
+*.swo
+*.swn
+*~
+.project
+.classpath
+.settings/
+*.sublime-project
+*.sublime-workspace
+
+# Operating System Files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+Desktop.ini
+
+# Project-specific
+citydata/
+citydata.zip
+__MACOSX/
+log/
+logs/*.log
+nohup.out
+
+# Credentials and secrets
+*.pem
+*.key
+credentials.json
+secret.json
+.secret
+
+# Database files
+*.db
+*.sqlite
+
+# Temporary files
+*.tmp
+*.temp
+.cache/
+
+# macOS
+.AppleDouble
+.LSOverride


### PR DESCRIPTION
## Summary

This PR regenerates the `.gitignore` file with comprehensive patterns for Python development, modern tooling, and project-specific needs.

## Changes

### Python Artifacts
- Byte-compiled files (*.pyc, *.pyo, *$py.class)
- Distribution/packaging files (dist/, build/, *.egg-info/)
- Cache directories (__pycache__)

### Virtual Environments
- .venv/, venv/, ENV/
- env/, env.bak/, venv.bak/

### Testing and Coverage
- .pytest_cache/
- .coverage, coverage.xml
- htmlcov/
- .tox/, .nox/

### Build Tools
- dist/, build/
- *.egg-info/
- .pybuilder/, target/

### Modern Tools
- **.uv/** - uv cache directory
- **uv.lock** - uv lock file
- poetry.lock
- Pipfile.lock

### IDEs and Editors
- .vscode/, .idea/
- *.swp, *.swo, *.swn
- *.sublime-project, *.sublime-workspace

### Environment and Secrets
- .env (but .env.example is tracked)
- *.pem, *.key
- credentials.json, secret.json

### Operating System Files
- .DS_Store, ._*
- Thumbs.db, Desktop.ini
- .AppleDouble, .LSOverride

### Project-specific
- citydata/ - dataset directory
- log/, logs/*.log
- nohup.out
- __MACOSX/

## Benefits

✅ **Security**: Prevents committing sensitive data (API keys, credentials)  
✅ **Clean repository**: Excludes build artifacts and cache files  
✅ **Modern tooling**: Supports uv, pytest, and other modern Python tools  
✅ **IDE agnostic**: Covers VS Code, PyCharm, and other editors  
✅ **Cross-platform**: Handles macOS, Windows, and Linux system files  
✅ **Comprehensive**: Based on GitHub's Python .gitignore template with project-specific additions

## Testing

The `.gitignore` file has been validated to include all necessary patterns while preserving important files like `.env.example` and `.gitkeep`.

Closes #12
